### PR TITLE
http-client changes to reflect headless api in context

### DIFF
--- a/plugins/http-client-html-json/http-client-html-json.js
+++ b/plugins/http-client-html-json/http-client-html-json.js
@@ -160,9 +160,8 @@ const HttpClient = (props, context) => {
   };
 
   return {
-    onRegistered: () => {
-      // Expose methods to context for use by other components
-      context.httpClient = {
+    // Expose methods to context for use by other components
+    api:{  
         // HTML methods
         getHtml,
         postHtml,
@@ -176,23 +175,17 @@ const HttpClient = (props, context) => {
         updateJson,
         deleteJson,
         patchJson
-      };
-
-      // Return cleanup function if needed
-      return () => {
-        delete context.httpClient;
-      };
-    }
+      }
   };
 };
 
 // Usage example in your Juris setup:
 // const app = new Juris({
-//   components: {
-//     client: HttpClient  // Register with alias 'client'
+//   headlessComponents: {
+//     client: { fn: HttpClient, options: { autoInit: true } }
 //   }
 // });
 //
 // Then in other components, use like:
-// context.httpClient.getHtml('/api/users', {}, 'users.list')
-// context.httpClient.postJson('/api/users', {name: 'John'}, 'users.created')
+// context.client.getHtml('/api/users', {}, 'users.list')
+// context.client.postJson('/api/users', {name: 'John'}, 'users.created')

--- a/plugins/http-client-html-json/http-client-readme.md
+++ b/plugins/http-client-html-json/http-client-readme.md
@@ -8,9 +8,7 @@ Simple, declarative HTTP requests that store responses directly in Juris state. 
 
 ```javascript
 const app = new Juris({
-    components: {
-        client: HttpClient
-    }
+    client: { fn: HttpClient, options: { autoInit: true } }
 });
 ```
 
@@ -78,7 +76,7 @@ Data is automatically converted to query parameters:
 
 ```javascript
 // This request:
-context.httpClient.getHtml('/api/users', {page: 1, limit: 10}, 'users.list');
+context.client.getHtml('/api/users', {page: 1, limit: 10}, 'users.list');
 
 // Becomes:
 // GET /api/users?page=1&limit=10
@@ -89,7 +87,7 @@ Data is sent as JSON in the request body:
 
 ```javascript
 // This request:
-context.httpClient.postJson('/api/users', {name: 'John', email: 'john@example.com'}, 'users.created');
+context.client.postJson('/api/users', {name: 'John', email: 'john@example.com'}, 'users.created');
 
 // Sends JSON body:
 // {"name": "John", "email": "john@example.com"}
@@ -101,7 +99,7 @@ Responses are automatically stored in Juris state as strings:
 
 ```javascript
 // After this request:
-context.httpClient.getHtml('/api/users', {}, 'users.list');
+context.client.getHtml('/api/users', {}, 'users.list');
 
 // You can access the HTML in components:
 app.enhance('.user-container', (props, { getState }) => ({


### PR DESCRIPTION
http-client had some old syntax i think. These changes seemed to work for me